### PR TITLE
Add LLM run capture, inspection, and matrix scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 *.pyo
 outputs/logs/
 **/.gitkeep
+experiments/

--- a/scripts/build_token_matrix.py
+++ b/scripts/build_token_matrix.py
@@ -1,0 +1,230 @@
+"""Stack all captured activations into a single token matrix.
+
+For each token in the prompt, collects:
+  - Hidden state from every layer           → n_layers+1 × hidden_dim
+  - Q, K, V vectors from every layer        → 3 × n_layers × hidden_dim
+  - MLP pre-activation from every layer     → n_layers × mlp_dim
+  - MLP post-activation from every layer    → n_layers × mlp_dim
+  - Mean attention received per layer       → n_layers  (scalar, fixed size)
+
+Result: matrix of shape  (seq_len, total_features)
+Saved as:
+  <run-dir>/exported/stacked_tokens.pt   — torch tensor
+  <run-dir>/exported/stacked_tokens.npy  — numpy array
+  <run-dir>/exported/stacked_tokens_meta.json — feature index map
+
+Usage:
+    python build_token_matrix.py --run-dir experiments/run_20240101_120000
+"""
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+
+# ── loaders ───────────────────────────────────────────────────────────────────
+
+def load_pt(path: Path) -> Any:
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
+# ── builder ───────────────────────────────────────────────────────────────────
+
+def build_token_matrix(run_dir: Path):
+    """
+    Returns:
+        matrix  — torch.Tensor  (seq_len, total_features)
+        meta    — dict describing which feature indices correspond to what
+    """
+
+    # ── load artifacts ───────────────────────────────────────────────────────
+    hs_path   = run_dir / "prompt_hidden_states.pt"
+    hook_path = run_dir / "prompt_hooks.pt"
+    att_path  = run_dir / "prompt_attentions.pt"
+
+    for p in (hs_path, hook_path, att_path):
+        if not p.exists():
+            raise FileNotFoundError(f"Required file not found: {p}")
+
+    hidden_states = load_pt(hs_path)   # tuple[ (1, seq, hidden) ]  len = n_layers+1
+    hooks         = load_pt(hook_path)  # dict key → list[tensor]
+    attentions    = load_pt(att_path)   # tuple[ (1, heads, seq, seq) ]  len = n_layers
+
+    # ── basic dimensions ─────────────────────────────────────────────────────
+    seq_len    = hidden_states[0].shape[1]   # number of prompt tokens
+    hidden_dim = hidden_states[0].shape[2]
+    n_hs_layers = len(hidden_states)         # includes embedding (layer 0)
+
+    # Detect number of transformer blocks from hooks
+    block_indices = sorted({
+        int(k.split(".")[1])
+        for k in hooks
+        if k.startswith("block.")
+    })
+    n_blocks = len(block_indices)
+
+    print(f"  tokens       : {seq_len}")
+    print(f"  hidden dim   : {hidden_dim}")
+    print(f"  hs layers    : {n_hs_layers}  (embedding + {n_hs_layers-1} transformer layers)")
+    print(f"  blocks (hooks): {n_blocks}")
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+
+    def hook_tensor(key: str) -> Optional[torch.Tensor]:
+        """Return the first tensor stored under a hook key, or None."""
+        val = hooks.get(key)
+        if val is None or len(val) == 0:
+            return None
+        t = val[0]  # first forward pass recording
+        if isinstance(t, torch.Tensor):
+            return t.float()
+        return None
+
+    def hook_slice(key: str, token_idx: int) -> Optional[torch.Tensor]:
+        """Return the feature vector for one token from a hook tensor."""
+        t = hook_tensor(key)
+        if t is None:
+            return None
+        # shape: (batch, seq, features)
+        if t.ndim == 3:
+            return t[0, token_idx, :]
+        # shape: (seq, features)
+        if t.ndim == 2:
+            return t[token_idx, :]
+        return None
+
+    # ── detect MLP dim from first available mlp_pre_act ──────────────────────
+    mlp_dim = 0
+    for b in block_indices:
+        t = hook_tensor(f"block.{b}.mlp_pre_act")
+        if t is not None:
+            mlp_dim = t.shape[-1]
+            break
+    print(f"  mlp dim      : {mlp_dim if mlp_dim else 'not captured'}")
+
+    # ── build feature index map ───────────────────────────────────────────────
+    # We record (name, start_idx, end_idx) for each feature group
+    meta_segments: List[Dict] = []
+    cursor = 0
+
+    def register(name: str, size: int) -> int:
+        nonlocal cursor
+        meta_segments.append({"name": name, "start": cursor, "end": cursor + size, "size": size})
+        cursor += size
+        return size
+
+    # Hidden states: one entry per layer (including embedding)
+    for l in range(n_hs_layers):
+        register(f"hidden_state.layer_{l}", hidden_dim)
+
+    # Q, K, V per block
+    for b in block_indices:
+        for proj in ("attn_q", "attn_k", "attn_v"):
+            t = hook_tensor(f"block.{b}.{proj}")
+            dim = t.shape[-1] if t is not None else hidden_dim
+            register(f"block_{b}.{proj}", dim)
+
+    # MLP pre / post activation per block
+    if mlp_dim > 0:
+        for b in block_indices:
+            register(f"block_{b}.mlp_pre_act",  mlp_dim)
+            register(f"block_{b}.mlp_post_act", mlp_dim)
+
+    # Mean attention received per layer (scalar → 1 feature per layer)
+    for l in range(len(attentions)):
+        register(f"attn_received_mean.layer_{l}", 1)
+
+    total_features = cursor
+    print(f"  total features: {total_features}")
+
+    # ── fill matrix ───────────────────────────────────────────────────────────
+    matrix = torch.zeros(seq_len, total_features, dtype=torch.float32)
+
+    for t_idx in range(seq_len):
+        vec = torch.zeros(total_features)
+        pos = 0
+
+        # Hidden states
+        for l, hs in enumerate(hidden_states):
+            if isinstance(hs, torch.Tensor):
+                vec[pos: pos + hidden_dim] = hs[0, t_idx, :].float()
+            pos += hidden_dim
+
+        # Q, K, V
+        for b in block_indices:
+            for proj in ("attn_q", "attn_k", "attn_v"):
+                sl = hook_slice(f"block.{b}.{proj}", t_idx)
+                t0 = hook_tensor(f"block.{b}.{proj}")
+                dim = t0.shape[-1] if t0 is not None else hidden_dim
+                if sl is not None:
+                    vec[pos: pos + dim] = sl
+                pos += dim
+
+        # MLP pre / post
+        if mlp_dim > 0:
+            for b in block_indices:
+                for hook_name in ("mlp_pre_act", "mlp_post_act"):
+                    sl = hook_slice(f"block.{b}.{hook_name}", t_idx)
+                    if sl is not None:
+                        vec[pos: pos + mlp_dim] = sl
+                    pos += mlp_dim
+
+        # Mean attention received by this token (averaged over heads and queries)
+        for l, att_layer in enumerate(attentions):
+            if isinstance(att_layer, torch.Tensor):
+                # att_layer: (1, heads, seq, seq) — axis -1 = key token
+                # column t_idx = how much attention token t_idx receives from others
+                received = att_layer[0, :, :, t_idx].mean().item()  # mean over heads & queries
+                vec[pos] = received
+            pos += 1
+
+        matrix[t_idx] = vec
+
+    return matrix, {"seq_len": seq_len, "total_features": total_features, "segments": meta_segments}
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build per-token feature matrix from run artifacts")
+    parser.add_argument("--run-dir", required=True,
+                        help="Path to run directory (e.g. experiments/run_20240101_120000)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_dir = Path(args.run_dir)
+
+    if not run_dir.exists():
+        print(f"Error: {run_dir} does not exist")
+        return
+
+    out_dir = run_dir / "exported"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Building token matrix from: {run_dir}")
+    matrix, meta = build_token_matrix(run_dir)
+
+    # Save
+    pt_path  = out_dir / "stacked_tokens.pt"
+    npy_path = out_dir / "stacked_tokens.npy"
+    meta_path = out_dir / "stacked_tokens_meta.json"
+
+    torch.save(matrix, pt_path)
+    np.save(npy_path, matrix.numpy())
+    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(f"\nMatrix shape : {list(matrix.shape)}  (tokens × features)")
+    print(f"Saved:")
+    print(f"  {pt_path.name}")
+    print(f"  {npy_path.name}")
+    print(f"  {meta_path.name}")
+    print(f"\nAll outputs in: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inspect_run.py
+++ b/scripts/inspect_run.py
@@ -1,0 +1,317 @@
+"""Inspect a run directory: export JSON and generate charts.
+
+All outputs are saved directly inside <run-dir>/ alongside the .pt files:
+  - <stem>.json           — tensor data (truncated for large tensors)
+  - plot_topk.png         — top-k token probabilities per generation step
+  - plot_hidden_norms.png — L2 norm of hidden states per layer
+  - plot_attention.png    — attention heatmap (layer 0, all heads, prompt pass)
+  - plot_logit_dist.png   — logit distribution across generation steps
+
+Usage:
+    python inspect_run.py --run-dir experiments/run_20240101_120000
+    python inspect_run.py --run-dir experiments/run_20240101_120000 --no-plots
+    python inspect_run.py --run-dir experiments/run_20240101_120000 --no-json
+"""
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def load_pt(path: Path) -> Any:
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
+def flatten_structure(obj: Any, prefix: str = "") -> Dict[str, torch.Tensor]:
+    """Recursively flatten nested tuples/lists/dicts of tensors → flat dict."""
+    result: Dict[str, torch.Tensor] = {}
+    if isinstance(obj, torch.Tensor):
+        result[prefix] = obj
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            result.update(flatten_structure(v, f"{prefix}.{k}" if prefix else str(k)))
+    elif isinstance(obj, (list, tuple)):
+        for i, v in enumerate(obj):
+            result.update(flatten_structure(v, f"{prefix}[{i}]" if prefix else f"[{i}]"))
+    return result
+
+
+def sanitize(values: List[float]) -> List:
+    """Replace non-finite floats with None for valid JSON."""
+    return [None if not np.isfinite(v) else v for v in values]
+
+
+def shape_summary(obj: Any, indent: int = 0) -> List[str]:
+    lines = []
+    pad = "  " * indent
+    if isinstance(obj, torch.Tensor):
+        arr = obj.float()
+        finite = arr[torch.isfinite(arr)]
+        stats = (f"min={finite.min():.4f}  max={finite.max():.4f}  mean={finite.mean():.4f}"
+                 if finite.numel() > 0 else "all non-finite")
+        lines.append(f"{pad}Tensor  shape={list(obj.shape)}  dtype={obj.dtype}  {stats}")
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            lines.append(f"{pad}['{k}']")
+            lines.extend(shape_summary(v, indent + 1))
+    elif isinstance(obj, (list, tuple)):
+        lines.append(f"{pad}{type(obj).__name__}  len={len(obj)}")
+        if len(obj) > 0:
+            lines.extend(shape_summary(obj[0], indent + 1))
+            if len(obj) > 1:
+                lines.append(f"{pad}  ... ({len(obj)} items total, showing first)")
+    else:
+        lines.append(f"{pad}{type(obj).__name__}: {obj}")
+    return lines
+
+
+# ── JSON export ───────────────────────────────────────────────────────────────
+
+def export_json(flat: Dict[str, torch.Tensor], run_dir: Path, stem: str) -> None:
+    MAX_ELEMENTS = 10_000
+    payload = {}
+    for key, tensor in flat.items():
+        arr = tensor.float().numpy()
+        total = arr.size
+        flat_data = sanitize(arr.flatten().tolist())
+        if total <= MAX_ELEMENTS:
+            payload[key] = {"shape": list(arr.shape), "data": flat_data}
+        else:
+            payload[key] = {
+                "shape": list(arr.shape),
+                "truncated": True,
+                "total_elements": int(total),
+                "data": flat_data[:MAX_ELEMENTS],
+            }
+    out_path = run_dir / f"{stem}.json"
+    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"  JSON → {out_path.name}")
+
+
+# ── charts ────────────────────────────────────────────────────────────────────
+
+def plot_topk(run_dir: Path, out_dir: Path) -> None:
+    """Bar chart: top-k token probabilities per generation step."""
+    import matplotlib.pyplot as plt
+
+    json_path = run_dir / "top_tokens_per_step.json"
+    if not json_path.exists():
+        print("  plot_topk: top_tokens_per_step.json not found, skipping")
+        return
+
+    steps = json.loads(json_path.read_text(encoding="utf-8"))
+    n_steps = len(steps)
+    if n_steps == 0:
+        return
+
+    show = min(n_steps, 10)
+    cols = 5
+    rows = (show + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(cols * 3.5, rows * 2.8))
+    axes = np.array(axes).flatten()
+
+    for i in range(show):
+        ax = axes[i]
+        step = steps[i]
+        topk = [(e["token"], e["logprob"]) for e in step["topk"] if e["logprob"] is not None]
+        topk = topk[:10]
+        tokens = [t.replace("\n", "\\n").replace(" ", "·") for t, _ in topk]
+        probs = np.exp([lp for _, lp in topk])
+        predicted = step["predicted_token"].replace("\n", "\\n").replace(" ", "·")
+        colors = ["#e74c3c" if t == predicted else "#3498db" for t in tokens]
+        ax.barh(range(len(tokens)), probs, color=colors)
+        ax.set_yticks(range(len(tokens)))
+        ax.set_yticklabels(tokens, fontsize=7)
+        ax.invert_yaxis()
+        ax.set_title(f"Step {step['step']}  →  \"{step['predicted_token'].strip()}\"",
+                     fontsize=8, pad=3)
+        ax.set_xlabel("probability", fontsize=7)
+        ax.tick_params(labelsize=7)
+
+    for j in range(show, len(axes)):
+        axes[j].set_visible(False)
+
+    fig.suptitle("Top-k token probabilities per generation step  (red = chosen)", fontsize=11)
+    plt.tight_layout()
+    out = out_dir / "plot_topk.png"
+    plt.savefig(out, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  plot → {out.name}")
+
+
+def plot_hidden_norms(run_dir: Path, out_dir: Path) -> None:
+    """Line chart: mean L2 norm of hidden states per layer."""
+    import matplotlib.pyplot as plt
+
+    pt_path = run_dir / "prompt_hidden_states.pt"
+    if not pt_path.exists():
+        print("  plot_hidden_norms: prompt_hidden_states.pt not found, skipping")
+        return
+
+    hidden_states = load_pt(pt_path)
+    norms = []
+    for layer_hs in hidden_states:
+        if isinstance(layer_hs, torch.Tensor):
+            norms.append(layer_hs.float().norm(dim=-1).mean().item())
+
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(range(len(norms)), norms, marker="o", linewidth=1.8, markersize=4, color="#2ecc71")
+    ax.fill_between(range(len(norms)), norms, alpha=0.15, color="#2ecc71")
+    ax.set_xlabel("Layer index  (0 = embedding)", fontsize=10)
+    ax.set_ylabel("Mean L2 norm", fontsize=10)
+    ax.set_title("Hidden state L2 norm per layer  (prompt pass)", fontsize=11)
+    ax.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+    out = out_dir / "plot_hidden_norms.png"
+    plt.savefig(out, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  plot → {out.name}")
+
+
+def plot_attention(run_dir: Path, out_dir: Path) -> None:
+    """Heatmap: attention weights for layer 0, all heads, prompt pass."""
+    import matplotlib.pyplot as plt
+
+    pt_path = run_dir / "prompt_attentions.pt"
+    if not pt_path.exists():
+        print("  plot_attention: prompt_attentions.pt not found, skipping")
+        return
+
+    attentions = load_pt(pt_path)
+    layer0 = attentions[0]
+    if not isinstance(layer0, torch.Tensor):
+        print("  plot_attention: unexpected format, skipping")
+        return
+
+    attn = layer0[0].float().numpy()  # (n_heads, seq, seq)
+    n_heads = attn.shape[0]
+    cols = min(n_heads, 4)
+    rows = (n_heads + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(cols * 3, rows * 2.8))
+    axes = np.array(axes).flatten()
+
+    for h in range(n_heads):
+        ax = axes[h]
+        ax.imshow(attn[h], aspect="auto", cmap="Blues", vmin=0, vmax=attn[h].max())
+        ax.set_title(f"Head {h}", fontsize=8)
+        ax.set_xlabel("key", fontsize=7)
+        ax.set_ylabel("query", fontsize=7)
+        ax.tick_params(labelsize=6)
+
+    for j in range(n_heads, len(axes)):
+        axes[j].set_visible(False)
+
+    fig.suptitle("Attention weights — layer 0, prompt pass", fontsize=11)
+    plt.tight_layout()
+    out = out_dir / "plot_attention.png"
+    plt.savefig(out, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  plot → {out.name}")
+
+
+def plot_logit_dist(run_dir: Path, out_dir: Path) -> None:
+    """Line chart: min/mean/max of finite logits per generation step."""
+    import matplotlib.pyplot as plt
+
+    pt_path = run_dir / "generation_logits.pt"
+    if not pt_path.exists():
+        print("  plot_logit_dist: generation_logits.pt not found, skipping")
+        return
+
+    gen_logits = load_pt(pt_path)
+    if not isinstance(gen_logits, torch.Tensor):
+        gen_logits = torch.stack(gen_logits)
+    gen_logits = gen_logits.float()
+
+    means, maxs, mins = [], [], []
+    for i in range(gen_logits.shape[0]):
+        row = gen_logits[i]
+        finite = row[torch.isfinite(row)]
+        if finite.numel() == 0:
+            means.append(float("nan"))
+            maxs.append(float("nan"))
+            mins.append(float("nan"))
+        else:
+            means.append(finite.mean().item())
+            maxs.append(finite.max().item())
+            mins.append(finite.min().item())
+
+    x = range(len(means))
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.plot(x, maxs,  label="max logit",  color="#e74c3c", linewidth=1.5)
+    ax.plot(x, means, label="mean logit", color="#3498db", linewidth=1.5)
+    ax.plot(x, mins,  label="min logit",  color="#95a5a6", linewidth=1.0, linestyle="--")
+    ax.fill_between(x, mins, maxs, alpha=0.07, color="#3498db")
+    ax.set_xlabel("Generation step", fontsize=10)
+    ax.set_ylabel("Logit value  (finite only)", fontsize=10)
+    ax.set_title("Logit distribution across generation steps", fontsize=11)
+    ax.legend(fontsize=9)
+    ax.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+    out = out_dir / "plot_logit_dist.png"
+    plt.savefig(out, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  plot → {out.name}")
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Inspect run artifacts: export JSON and charts")
+    parser.add_argument("--run-dir", required=True,
+                        help="Path to a run directory (e.g. experiments/run_20240101_120000)")
+    parser.add_argument("--no-plots", action="store_true", help="Skip chart generation")
+    parser.add_argument("--no-json",  action="store_true", help="Skip JSON export")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_dir = Path(args.run_dir)
+
+    if not run_dir.exists():
+        print(f"Error: run directory not found: {run_dir}")
+        return
+
+    out_dir = run_dir / "exported"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── JSON export ───────────────────────────────────────────────────────────
+    if not args.no_json:
+        pt_files = sorted(run_dir.glob("*.pt"))
+        if pt_files:
+            print(f"Exporting {len(pt_files)} .pt files to JSON...")
+            for pt_path in pt_files:
+                stem = pt_path.stem
+                data = load_pt(pt_path)
+                for line in shape_summary(data):
+                    print("   " + line)
+                flat = flatten_structure(data)
+                export_json(flat, out_dir, stem)
+                print()
+        else:
+            print("No .pt files found.")
+
+    # ── charts ────────────────────────────────────────────────────────────────
+    if not args.no_plots:
+        try:
+            import matplotlib
+            matplotlib.use("Agg")
+            print("Generating charts...")
+            plot_topk(run_dir, out_dir)
+            plot_hidden_norms(run_dir, out_dir)
+            plot_attention(run_dir, out_dir)
+            plot_logit_dist(run_dir, out_dir)
+        except ImportError:
+            print("matplotlib not installed — skipping charts.  Run: pip install matplotlib")
+
+    print(f"\nDone. All outputs saved to: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_llm_capture.py
+++ b/scripts/run_llm_capture.py
@@ -1,0 +1,370 @@
+"""Run a local LLM and persist raw internals for a prompt."""
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Callable, Dict, List, Sequence, Tuple, Union
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+TensorNest = Union[torch.Tensor, Sequence[torch.Tensor], Sequence[Sequence[torch.Tensor]]]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Capture hidden states, attentions, logits, and top tokens from a local LLM")
+    parser.add_argument("--prompt", default="The meaning of life is", help="Text prompt to feed into the model (default in code if not provided)")
+    parser.add_argument("--model", default="gpt2", help="Model identifier (e.g., 'gpt2' or 'meta-llama/Llama-3.2-1B')")
+    parser.add_argument("--max-new-tokens", type=int, default=50, help="Number of tokens to generate")
+    parser.add_argument("--temperature", type=float, default=0.7, help="Sampling temperature")
+    parser.add_argument("--top-p", type=float, default=0.9, help="Top-p nucleus sampling value")
+    parser.add_argument("--top-k", type=int, default=20, help="Top-k tokens to keep per step")
+    parser.add_argument("--output-dir", default="experiments", help="Base directory to store run outputs")
+    parser.add_argument("--trust-remote-code", action="store_true", help="Allow execution of custom model code from hub")
+    return parser.parse_args()
+
+
+def move_nested_to_cpu(nested: TensorNest) -> TensorNest:
+    """Recursively detach tensors and move them to CPU."""
+    if isinstance(nested, torch.Tensor):
+        return nested.detach().cpu()
+    if isinstance(nested, (list, tuple)):
+        return type(nested)(move_nested_to_cpu(x) for x in nested)
+    return nested
+
+
+class ActivationRecorder:
+    def __init__(self) -> None:
+        self.data: Dict[str, List[torch.Tensor]] = defaultdict(list)
+
+    def add(self, key: str, tensor: torch.Tensor) -> None:
+        if tensor is None:
+            return
+        # Some modules (e.g. transformer blocks) return tuples; take the first element
+        if isinstance(tensor, tuple):
+            tensor = tensor[0]
+        if not isinstance(tensor, torch.Tensor):
+            return
+        self.data[key].append(tensor.detach().cpu())
+
+    def to_dict(self) -> Dict[str, List[torch.Tensor]]:
+        return dict(self.data)
+
+
+def register_gpt2_hooks(model: AutoModelForCausalLM, get_rec: Callable[[], ActivationRecorder]) -> List:
+    """Attach forward hooks for GPT-2 style modules to capture internal activations."""
+    handles = []
+
+    def add(name: str, tensor: torch.Tensor) -> None:
+        rec = get_rec()
+        if rec is not None:
+            rec.add(name, tensor)
+
+    # Embeddings
+    if hasattr(model, "transformer"):
+        tr = model.transformer
+        if hasattr(tr, "wte"):
+            handles.append(tr.wte.register_forward_hook(lambda m, inp, out: add("embed_token", out)))
+        if hasattr(tr, "wpe"):
+            handles.append(tr.wpe.register_forward_hook(lambda m, inp, out: add("embed_position", out)))
+
+        # Blocks
+        if hasattr(tr, "h"):
+            for idx, block in enumerate(tr.h):
+                name = f"block.{idx}"
+
+                # ln_1 input/output
+                if hasattr(block, "ln_1"):
+                    handles.append(block.ln_1.register_forward_pre_hook(lambda m, inp, n=name: add(f"{n}.ln1_in", inp[0])))
+                    handles.append(block.ln_1.register_forward_hook(lambda m, inp, out, n=name: add(f"{n}.ln1_out", out)))
+
+                # Q, K, V — split output of c_attn (GPT-2 fuses QKV into one projection)
+                # c_attn output shape: (batch, seq, 3 * embed_dim) → split into equal thirds
+                if hasattr(block, "attn") and hasattr(block.attn, "c_attn"):
+                    def _qkv_hook(m, inp, out, n=name):
+                        embed_dim = out.shape[-1] // 3
+                        q, k, v = out.split(embed_dim, dim=-1)
+                        add(f"{n}.attn_q", q)
+                        add(f"{n}.attn_k", k)
+                        add(f"{n}.attn_v", v)
+                    handles.append(block.attn.c_attn.register_forward_hook(_qkv_hook))
+
+                # attention output (pre-residual add)
+                if hasattr(block, "attn"):
+                    handles.append(block.attn.register_forward_hook(lambda m, inp, out, n=name: add(f"{n}.attn_out", out[0] if isinstance(out, tuple) else out)))
+
+                # ln_2 input/output
+                if hasattr(block, "ln_2"):
+                    handles.append(block.ln_2.register_forward_pre_hook(lambda m, inp, n=name: add(f"{n}.ln2_in", inp[0])))
+                    handles.append(block.ln_2.register_forward_hook(lambda m, inp, out, n=name: add(f"{n}.ln2_out", out)))
+
+                # MLP pre-activation: output of c_fc before GELU
+                if hasattr(block, "mlp") and hasattr(block.mlp, "c_fc"):
+                    handles.append(block.mlp.c_fc.register_forward_hook(lambda m, inp, out, n=name: add(f"{n}.mlp_pre_act", out)))
+
+                # MLP post-activation: output of GELU before c_proj
+                if hasattr(block, "mlp") and hasattr(block.mlp, "act"):
+                    handles.append(block.mlp.act.register_forward_hook(lambda m, inp, out, n=name: add(f"{n}.mlp_post_act", out)))
+
+                # mlp output (pre-residual add)
+                if hasattr(block, "mlp"):
+                    handles.append(block.mlp.register_forward_hook(lambda m, inp, out, n=name: add(f"{n}.mlp_out", out)))
+
+                # block output (post both residual adds)
+                handles.append(block.register_forward_hook(lambda m, inp, out, n=name: add(f"{n}.block_out", out)))
+
+        # Final layernorm
+        if hasattr(tr, "ln_f"):
+            handles.append(tr.ln_f.register_forward_hook(lambda m, inp, out: add("ln_f_out", out)))
+
+    return handles
+
+
+def topk_per_step(
+    scores: List[torch.Tensor],
+    tokenizer: AutoTokenizer,
+    prompt_len: int,
+    generated_ids: torch.Tensor,
+    k: int,
+) -> List[Dict]:
+    """Collect top-k logprobs for every generation step."""
+    per_step: List[Dict] = []
+    for i, step_scores in enumerate(scores):
+        log_probs = torch.log_softmax(step_scores[0], dim=-1)
+        top_log_probs, top_indices = torch.topk(log_probs, k=k)
+        predicted_token_id = int(generated_ids[prompt_len + i])
+        per_step.append(
+            {
+                "step": i,
+                "predicted_token_id": predicted_token_id,
+                "predicted_token": tokenizer.decode([predicted_token_id]),
+                "topk": [
+                    {
+                        "token": tokenizer.decode([idx]),
+                        "token_id": int(idx),
+                        "logprob": float(lp) if lp != float("-inf") else None,
+                    }
+                    for lp, idx in zip(top_log_probs.tolist(), top_indices.tolist())
+                ],
+            }
+        )
+    return per_step
+
+
+def save_run_artifacts(
+    run_dir: Path,
+    generated_text: str,
+    prompt_hidden_states: TensorNest,
+    prompt_attentions: TensorNest,
+    prompt_logits: torch.Tensor,
+    prompt_hooks: Dict[str, List[torch.Tensor]],
+    fullseq_hooks: Dict[str, List[torch.Tensor]],
+    gen_hidden_states: TensorNest,
+    gen_attentions: TensorNest,
+    gen_logits: torch.Tensor,
+    top_tokens_first_step: Dict,
+    top_tokens_all_steps: List[Dict],
+    metadata: Dict,
+) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    (run_dir / "generated.txt").write_text(generated_text, encoding="utf-8")
+    torch.save(prompt_hidden_states, run_dir / "prompt_hidden_states.pt")
+    torch.save(prompt_attentions, run_dir / "prompt_attentions.pt")
+    torch.save(prompt_logits, run_dir / "prompt_logits.pt")
+    torch.save(prompt_hooks, run_dir / "prompt_hooks.pt")
+    torch.save(fullseq_hooks, run_dir / "full_sequence_hooks.pt")
+    torch.save(gen_hidden_states, run_dir / "generation_hidden_states.pt")
+    torch.save(gen_attentions, run_dir / "generation_attentions.pt")
+    torch.save(gen_logits, run_dir / "generation_logits.pt")
+    (run_dir / "top_tokens_first_step.json").write_text(
+        json.dumps(top_tokens_first_step, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (run_dir / "top_tokens_per_step.json").write_text(
+        json.dumps(top_tokens_all_steps, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (run_dir / "config.json").write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    base_dir = Path(args.output_dir)
+    timestamp = dt.datetime.now().strftime("run_%Y%m%d_%H%M%S")
+    run_dir = base_dir / timestamp
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=args.trust_remote_code)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        output_hidden_states=True,
+        output_attentions=True,
+        trust_remote_code=args.trust_remote_code,
+        torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
+        device_map="auto" if torch.cuda.is_available() else None,
+    )
+    model.to(device)
+    model.eval()
+
+    prompt_hooks = ActivationRecorder()
+    fullseq_hooks = ActivationRecorder()
+
+    active_rec: Dict[str, ActivationRecorder] = {"rec": None}
+    def get_rec() -> ActivationRecorder:
+        return active_rec["rec"]
+
+    hook_handles = register_gpt2_hooks(model, get_rec)
+
+    encoded = tokenizer(args.prompt, return_tensors="pt")
+    encoded = {k: v.to(device) for k, v in encoded.items()}
+    prompt_len = encoded["input_ids"].shape[1]
+
+    with torch.no_grad():
+        active_rec["rec"] = prompt_hooks
+        prompt_forward = model(
+            **encoded,
+            output_hidden_states=True,
+            output_attentions=True,
+            use_cache=False,
+            return_dict=True,
+        )
+        active_rec["rec"] = None
+
+    with torch.no_grad():
+        outputs = model.generate(
+            **encoded,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            do_sample=True,
+            return_dict_in_generate=True,
+            output_hidden_states=True,
+            output_attentions=True,
+            output_scores=True,
+            use_cache=True,
+        )
+
+    generated_ids = outputs.sequences[0]
+    generated_text = tokenizer.decode(generated_ids, skip_special_tokens=True)
+
+    # Full-sequence forward pass (prompt + generated) to capture deep activations with hooks
+    full_seq_inputs = {"input_ids": generated_ids.unsqueeze(0).to(device)}
+    if "attention_mask" in encoded:
+        full_seq_inputs["attention_mask"] = torch.ones_like(full_seq_inputs["input_ids"], device=device)
+    with torch.no_grad():
+        active_rec["rec"] = fullseq_hooks
+        _ = model(
+            **full_seq_inputs,
+            output_hidden_states=True,
+            output_attentions=True,
+            use_cache=False,
+            return_dict=True,
+        )
+        active_rec["rec"] = None
+
+    prompt_hidden_states = move_nested_to_cpu(prompt_forward.hidden_states)
+    prompt_attentions = move_nested_to_cpu(prompt_forward.attentions)
+    prompt_logits = prompt_forward.logits.detach().cpu()
+
+    gen_hidden_states = move_nested_to_cpu(outputs.hidden_states)
+    gen_attentions = move_nested_to_cpu(outputs.attentions)
+
+    gen_logits = torch.stack(outputs.scores).squeeze(1).detach().cpu()
+
+    first_step_scores = outputs.scores[0][0]
+    log_probs = torch.log_softmax(first_step_scores, dim=-1)
+    top_log_probs, top_indices = torch.topk(log_probs, k=args.top_k)
+    top_tokens_first_step = {
+        "topk": [
+            {
+                "token": tokenizer.decode([idx]),
+                "token_id": int(idx),
+                "logprob": float(lp) if lp != float("-inf") else None,
+            }
+            for lp, idx in zip(top_log_probs.tolist(), top_indices.tolist())
+        ]
+    }
+
+    top_tokens_all_steps = topk_per_step(
+        scores=outputs.scores,
+        tokenizer=tokenizer,
+        prompt_len=prompt_len,
+        generated_ids=generated_ids,
+        k=args.top_k,
+    )
+
+    metadata = {
+        "prompt": args.prompt,
+        "model_name": args.model,
+        "max_new_tokens": args.max_new_tokens,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "top_k": args.top_k,
+        "device": device,
+        "timestamp": timestamp,
+        "prompt_length": prompt_len,
+        "generated_length": len(generated_ids) - prompt_len,
+    }
+
+    save_run_artifacts(
+        run_dir=run_dir,
+        generated_text=generated_text,
+        prompt_hidden_states=prompt_hidden_states,
+        prompt_attentions=prompt_attentions,
+        prompt_logits=prompt_logits,
+        prompt_hooks=prompt_hooks.to_dict(),
+        fullseq_hooks=fullseq_hooks.to_dict(),
+        gen_hidden_states=gen_hidden_states,
+        gen_attentions=gen_attentions,
+        gen_logits=gen_logits,
+        top_tokens_first_step=top_tokens_first_step,
+        top_tokens_all_steps=top_tokens_all_steps,
+        metadata=metadata,
+    )
+
+    for h in hook_handles:
+        h.remove()
+
+    print("\n" + "=" * 60)
+    print(f"PROMPT:\n  {args.prompt}")
+    print("-" * 60)
+    print(f"RESPONSE:\n  {generated_text[len(args.prompt):].strip()}")
+    print("=" * 60 + "\n")
+    print(f"Saved run to: {run_dir}")
+
+    # Auto-run inspect_run.py to convert .pt files to JSON
+    inspect_script = Path(__file__).parent / "inspect_run.py"
+    if inspect_script.exists():
+        print("\nRunning inspect_run.py...")
+        result = subprocess.run(
+            [sys.executable, str(inspect_script), "--run-dir", str(run_dir)],
+            check=False,
+        )
+        if result.returncode != 0:
+            print("Warning: inspect_run.py finished with errors.")
+    else:
+        print(f"Warning: inspect_run.py not found at {inspect_script}, skipping export.")
+
+    # Auto-run build_token_matrix.py to stack all activations into one matrix
+    matrix_script = Path(__file__).parent / "build_token_matrix.py"
+    if matrix_script.exists():
+        print("\nRunning build_token_matrix.py...")
+        result = subprocess.run(
+            [sys.executable, str(matrix_script), "--run-dir", str(run_dir)],
+            check=False,
+        )
+        if result.returncode != 0:
+            print("Warning: build_token_matrix.py finished with errors.")
+    else:
+        print(f"Warning: build_token_matrix.py not found at {matrix_script}, skipping.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add three utility scripts for capturing and analyzing local LLM runs and update .gitignore. run_llm_capture.py runs a model, records hidden states/attentions/logits/hooks and top-k token info, saves run artifacts, and invokes inspection and matrix building. inspect_run.py exports .pt artifacts to JSON (truncating large tensors) and optionally generates charts (top-k, hidden norms, attention heatmaps, logit distributions). build_token_matrix.py stacks per-token features (hidden states, Q/K/V, MLP pre/post, mean attention, etc.) into a single token×feature matrix and writes .pt/.npy plus metadata. Also add "experiments/" to .gitignore to ignore run output directories.